### PR TITLE
Add workaround for empty extension config error

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,1 +1,4 @@
 # empty dragsort configuration file
+# Workaround broken Bolt extensions page caused by empty extension config.
+# See https://github.com/bolt/core/issues/3158
+foo: true


### PR DESCRIPTION
There's an error with the Bolt Extensions page, because the page assumes all extensions have at least _some_ config.

See https://github.com/bolt/core/issues/3158.

For now, adding a meaningless `foo: true` config setting fixes the issue.