### PR TITLE
Use `path()` to avoid mixed content error - Fixes #5

### DIFF
--- a/templates/injector.html.twig
+++ b/templates/injector.html.twig
@@ -22,7 +22,7 @@
 
             $.ajax({
                 type: 'POST',
-                url: '{{ url('dragsort_sort', parameters = [], schemeRelative = false) }}',
+                url: '{{ path('dragsort_sort', parameters = [], relative = false) }}',
                 data: data,
                 success: function () {
                     // TODO


### PR DESCRIPTION
Using symfony's `path()` method creates a relative URL to the dragsort API. Dropping the domain and scheme resolves the mixed content error noted in #5 .

See https://symfony.com/doc/current/templates.html#linking-to-pages